### PR TITLE
Update to use Material for MkDocs Insiders

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -32,9 +32,14 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
-      - name: Install mkdoks-material
+      - name: Install mkdocs-material
+        env:
+          GH_TOKEN: ${{ secrets.MATERIAL_FOR_MKDOCS_INSIDER_PAT }}
         run: |
-          pip install mkdocs-material
+          pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
+
+      - name: Install plugins
+        run: |
           pip install mkdocs-git-authors-plugin
           pip install mkdocs-git-revision-date-localized-plugin
           pip install mkdocs-git-committers-plugin-2


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/Docs.yml` file to improve the installation process for `mkdocs-material` and its plugins. The most important change is the switch to using the insider version of `mkdocs-material` with authentication.

### Workflow improvements:

* `Install mkdocs-material` step: Updated to install the insider version of `mkdocs-material` using a GitHub token (`GH_TOKEN`) for authentication. This ensures access to the premium features of the package.
* Plugin installation: Adjusted the installation sequence to separate the `mkdocs-material` insider installation from the other plugins.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
